### PR TITLE
Board

### DIFF
--- a/Assets/Scenes/Level 1.unity
+++ b/Assets/Scenes/Level 1.unity
@@ -357,7 +357,7 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_Sprite: {fileID: 10907, guid: 0000000000000000f000000000000000, type: 0}
+  m_Sprite: {fileID: 10917, guid: 0000000000000000f000000000000000, type: 0}
   m_Type: 1
   m_PreserveAspect: 0
   m_FillCenter: 1

--- a/Assets/Scenes/Level 1.unity
+++ b/Assets/Scenes/Level 1.unity
@@ -287,15 +287,15 @@ RectTransform:
   m_GameObject: {fileID: 96526712}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_LocalScale: {x: 1.1125, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 138367375}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: 0, y: -85}
-  m_SizeDelta: {x: 0, y: -472.58508}
+  m_AnchoredPosition: {x: -4, y: -71.83301}
+  m_SizeDelta: {x: 0, y: -496.1603}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &96526714
 MonoBehaviour:
@@ -315,7 +315,7 @@ MonoBehaviour:
     m_Top: 0
     m_Bottom: 0
   m_ChildAlignment: 1
-  m_Spacing: -25
+  m_Spacing: -7
   m_ChildForceExpandWidth: 1
   m_ChildForceExpandHeight: 1
   m_ChildControlWidth: 1


### PR DESCRIPTION
Fixed the issue where spawned cubes were overlapping with one another. The vertical layout group was keeping them tightly packed and was causing the tiles to overlap, hence the cubes that spanned their parent were also overlapping. I gave the vertical layout group a tiny amount of negative spacing to fix the issue.